### PR TITLE
Add Debian 12 support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,4 @@ description      'Installs/Configures apt-osuosl'
 version          '2.1.0'
 
 supports         'debian', '~> 11.0'
+supports         'debian', '~> 12.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: apt-osuosl
 # Recipe:: default
 #
-# Copyright:: 2020-2022, Oregon State University
+# Copyright:: 2020-2023, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,14 @@ DEBIAN_11 = {
   version: '11',
 }.freeze
 
+DEBIAN_12 = {
+  platform: 'debian',
+  version: '12',
+}.freeze
+
 ALL_PLATFORMS = [
   DEBIAN_11,
+  DEBIAN_12,
 ].freeze
 
 RSpec.configure do |config|


### PR DESCRIPTION
PR for adding Debian 12 OS support to this cookbook. Rspec/unit testing should be complete which was confirmed on my local by using the fauxhai branch which supports Debian 12(not merged yet).